### PR TITLE
enhancement:docs-and-walletmultibutton

### DIFF
--- a/packages/anchor/README.md
+++ b/packages/anchor/README.md
@@ -14,13 +14,22 @@ npm i @svelte-on-solana/wallet-adapter-anchor
 
 Add `@project-serum/anchor` to `optimizeDeps`. This pre-bundles the `@project-serum/anchor` package. This steps converts commonJs dependencies into ESM ( Vite's dev server serves all code as native ESM ).
 
-```
- kit: {
-    vite: {
-      optimizeDeps: {
-        include: ['@project-serum/anchor'],
-      },
-      // ---
+```javascript
+const config = {
+	// ...
+	kit: {
+		// ...
+		vite: {
+			// ...
+			define: {
+				'process.env.BROWSER': true
+			},
+			optimizeDeps: {
+				include: ['@project-serum/anchor']
+			}
+		}
+	}
+};
 ```
 
 The `AnchorConnectionProvider` for Anchor Dapps accepts the next props.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -63,8 +63,14 @@ const config = {
 
 	kit: {
 		// ...
-		define: {
-			'process.env.BROWSER': true
+		vite: {
+			// ...
+			define: {
+				'process.env.BROWSER': true
+			},
+			optimizeDeps: {
+				include: ['@solana/web3.js', 'buffer']
+			}
 		}
 	}
 };

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -59,8 +59,7 @@ You have to adjust the **svelte.config.js** file to prepare the project for all 
 
 ```javascript
 const config = {
-	preprocess: preprocess(),
-
+	// ...
 	kit: {
 		// ...
 		vite: {

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -150,7 +150,7 @@ export default {
 		resolve({
 			browser: true,
 			dedupe: ['svelte'],
-			preferBuiltins: false // set this to false
+			preferBuiltins: false
 		}),
 		// ... more rollup plugins
 		json(),

--- a/packages/ui/src/lib/WalletMultiButton.svelte
+++ b/packages/ui/src/lib/WalletMultiButton.svelte
@@ -72,7 +72,7 @@
 
 {#if !wallet}
 	<WalletButton class="wallet-adapter-button-trigger" on:click={openModal}>
-		Select Wallet
+		<slot>Select Wallet</slot>
 	</WalletButton>
 {:else if !base58}
 	<WalletConnectButton />


### PR DESCRIPTION
The adjustments in this PR are related with #23 

- Docs are showing now how `svelte.config.js` file should be in case using just Solana
- The `svelte.config.js` for Anchor and Solana in SvelteKit are more aligned and fixed. 
- The wallet multi button has the option to custom text using `<slot/>`