### PR TITLE
Allow the number of wallets shown in the modal to be configured when …

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -53,6 +53,10 @@ Alternatively you can use `AnchorConnectionProvider` for Anchor Dapps.
 
 `WalletMultiButton` is a component used as the entry point to connect/disconnect a wallet.
 
+| prop               | type     | default |
+| ------------------ | -------- | ------- |
+| maxNumberOfWallets | `number` | `3`     |
+
 ## SvelteKit
 
 You have to adjust the **svelte.config.js** file to prepare the project for all the Solana packages previously installed.

--- a/packages/ui/src/lib/WalletModal.svelte
+++ b/packages/ui/src/lib/WalletModal.svelte
@@ -3,7 +3,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import WalletButton from './WalletButton.svelte';
 
-	export let maxNumberOfWallets = 3;
+	export let maxNumberOfWallets;
 
 	let showMoreOptions = false,
 		backdrop: HTMLDivElement,
@@ -79,7 +79,7 @@
 					class:wallet-adapter-modal-collapse-button-active={showMoreOptions}
 					on:click={() => toggleMoreOptions()}
 				>
-					{showMoreOptions ? 'Less' : 'More'} options
+					{showMoreOptions ? 'Fewer' : 'More'} options
 
 					<svg width="11" height="6" xmlns="http://www.w3.org/2000/svg">
 						<path

--- a/packages/ui/src/lib/WalletMultiButton.svelte
+++ b/packages/ui/src/lib/WalletMultiButton.svelte
@@ -5,6 +5,8 @@
 	import WalletModal from './WalletModal.svelte';
 	import './styles.css';
 
+	export let maxNumberOfWallets = 3;
+
 	$: ({ publicKey, wallet, disconnect, connect, select } = $walletStore);
 
 	let dropDrownVisible = false,
@@ -90,7 +92,6 @@
 				class="wallet-adapter-dropdown-list wallet-adapter-dropdown-list-active"
 				role="menu"
 				use:clickOutside={() => {
-					console.log(`clickOutsiede`, dropDrownVisible);
 					if (dropDrownVisible) {
 						closeDropdown();
 					}
@@ -115,5 +116,5 @@
 {/if}
 
 {#if modalVisible}
-	<WalletModal on:close={closeModal} on:connect={connectWallet} />
+	<WalletModal on:close={closeModal} on:connect={connectWallet} {maxNumberOfWallets} />
 {/if}


### PR DESCRIPTION
Adds `WalletModal`'s `maxNumberOfWallets` prop to `WalletMultiButton` to allow configuration of the number of wallets displayed in the modal. 

Based off of a discussion here: https://github.com/svelte-on-solana/wallet-adapter/issues/26 