### PR TITLE
enhancement:walletstore-type-exportable

### DIFF
--- a/packages/core/src/walletStore.ts
+++ b/packages/core/src/walletStore.ts
@@ -20,7 +20,7 @@ type ErrorHandler = (error: WalletError) => void;
 type WalletConfig = Pick<WalletStore, 'wallets' | 'autoConnect' | 'localStorageKey' | 'onError'>;
 type WalletStatus = Pick<WalletStore, 'connected' | 'publicKey'>;
 
-interface WalletStore {
+export interface WalletStore {
 	// props
     autoConnect: boolean;
     wallets: Adapter[];


### PR DESCRIPTION
**Changes**:

type WalletStore exportable. Closes #28 

**How to test**:

Just from the client try to import the type to be used in the Svelte components