### PR TITLE
Support VersionedTransaction on sendTransaction

### DIFF
--- a/packages/core/src/walletStore.ts
+++ b/packages/core/src/walletStore.ts
@@ -329,7 +329,7 @@ async function select(walletName: WalletName): Promise<void> {
 }
 
 async function sendTransaction(
-    transaction: Transaction,
+    transaction: Transaction | VersionedTransaction,
     connection: Connection,
     options?: SendTransactionOptions
 ): Promise<TransactionSignature> {


### PR DESCRIPTION
Update of Solana Web3 to support `VersionedTransaction` 